### PR TITLE
add jsonResourcePath option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -81,13 +81,14 @@ If you are writing content that uses specialist vocabulary or many acronyms you 
 
 
     defaults = {
-      sourceURL     : '', 
-      replaceTag    : 'abbr', 
-      lookupTagName : 'p, ul, a',
-      callback      : null,
-      replaceOnce   : true,
-      replaceClass  : glossarizer_replaced,
-      caseSensitive : false
+      sourceURL        : '', 
+      replaceTag       : 'abbr', 
+      lookupTagName    : 'p, ul, a',
+      callback         : null,
+      replaceOnce      : true,
+      replaceClass     : glossarizer_replaced,
+      caseSensitive    : false,
+      jsonResourcePath : false
     }
 
 
@@ -102,6 +103,29 @@ Attribute  | Options                   | Default             | Description
 `replaceClass`    | *string*                  | `glossarizer_replaced`               | Class name of the replaceTag
 `callback`    | *method*                  | `null`               | Completed callback 
 `caseSensitive`    | *boolean*                  | `false`               | Match case sensitive
+`jsonResourcePath`    | *string*                  | `false`               | JSON rsource path for returned data
+
+## JSON Resource Path
+
+Data may sometimes be returned as an attribute on an object, like: 
+
+    {
+      "glossary": {
+        "count": 2,
+        "terms": [
+          {
+            "term": "death, !death star",
+            "description": "Cessation of all biological functions"
+          },
+          {
+            "term": "genetic, !genetic testing, genes, DNA",
+            "description": "relating to genes or heredity: genetic abnormalities."
+          }
+        ]
+      }
+    }
+
+The JSON Resource Path option specifies the path in the JSON object to the properly formatted data, in this case, you could provide `['glossary']['terms']`.
 
 ## External Methods
 

--- a/jquery.glossarize.js
+++ b/jquery.glossarize.js
@@ -34,7 +34,8 @@
       replaceOnce: false, /* Replace only once in a TextNode */
       replaceClass: 'glossarizer_replaced',
       caseSensitive: false,
-      exactMatch: false
+      exactMatch: false,
+      jsonResourcePath: false
   }
 
   /**
@@ -71,8 +72,18 @@
 
     /* Fetch glossary JSON */
 
-    $.getJSON(this.options.sourceURL).then(function (data) {
-      base.glossary = data
+    $.getJSON(this.options.sourceURL).then($.proxy(function (data) {
+      if (this.options.jsonResourcePath) {
+        var pathParts = this.options.jsonResourcePath.split("']['");
+        pathParts = $.map(pathParts, function(v, i) {
+          return v.replace(/[\[\]\']+/g, '');
+        });
+        $.each(pathParts, function(i, v) {
+          base.glossary = data[v];
+        })
+      } else {
+        base.glossary = data
+      }
 
       if (!base.glossary.length || base.glossary.length == 0) return
 
@@ -106,7 +117,7 @@
        */
 
       base.wrapTerms()
-    })
+    }, this))
   }
 
   /**


### PR DESCRIPTION
In my case, the framework I'm currently working with will not return the bare json array for the glossary, it's in a `data` resource key. 

This pull request allows one to specify the path, `['data']`, to the glossary terms. 

It works by splitting the user-provided string into segments, so it can handle deeply-nested data like `['results']['data']['glossary']['terms']`, then loops through the parts reassigning `base.glossary` to the final array in the JSON object.

This could perhaps be better solved by introducing an option to specify the JSON object that should be used or by introducing an option that accepts a function to return the necessary JSON data, but it's what I came up with in a pinch.

The README has also been updated with an example. Tests have not been updated or ran.